### PR TITLE
OrangeMouseData: Use correct variable in getSwitchId

### DIFF
--- a/OrangeMouseData.js
+++ b/OrangeMouseData.js
@@ -61,7 +61,7 @@ var OrangeMouseData = OrangeMouseData || {};
   $.Param.switchMiddleButtonDown = Number($.Parameters['switchMiddleButtonDown'] || 0);
 
   $.getSwitchId = function(mouseButton) {
-    switch(event.button) {
+    switch(mouseButton) {
       case 0 :
         return $.Param.switchLeftButtonDown;
       case 1 :


### PR DESCRIPTION
Fixes an "event is undefined" bug in Firefox

When running MV in Firefox getSwitchId fails because event is undefined, the argument is called mouseButton.
I have no idea why Chrome/Webkit doesn't fail, "event" is obviously undefined in that scope o.O